### PR TITLE
Remove custom formatter for date

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -111,9 +111,9 @@ async function generateSchema(pathToSpec) {
     supportArrayLength: flags.supportArrayLength,
     pathParamsAsTypes: flags.pathParamsAsTypes,
     // Configure openapiTS with custom formatter.
-    // If node.format is date or date-time, use JavaScript Date type.
+    // If node.format is date-time, use JavaScript Date type.
     formatter: (node) => {
-      if (node.format === "date" || node.format === "date-time") {
+      if (node.format === "date-time") {
         return "Date";
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opkit/openapi-typescript",
   "description": "Generate TypeScript types from Swagger OpenAPI specs",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "engines": {
     "node": ">= 14.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opkit/openapi-typescript",
   "description": "Generate TypeScript types from Swagger OpenAPI specs",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "engines": {
     "node": ">= 14.0.0"
   },


### PR DESCRIPTION
Contrary to what I previously believed, it is not good to generate the type "Date" for fields that are regular date strings (e.g. 2021-01-01). This is because Javascript Dates are actually date-times; they always include a time and timezone. See:

<img width="279" alt="image" src="https://user-images.githubusercontent.com/7094076/201435513-36324848-7d2a-4ad2-8f8b-666ab3db1df0.png">


When our API is sending/receiving regular date strings, we do not want to accidentally add times + timezones.